### PR TITLE
Fix: Normalize line endings in content comparison to prevent false modified updates

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,5 @@
-import { App, MarkdownView, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 
 export async function getFileContent(app: App, file: TFile): Promise<string> {
-	for (const leaf of app.workspace.getLeavesOfType("markdown")) {
-		const view = leaf.view;
-		if (view instanceof MarkdownView && view.file?.path === file.path) {
-			return view.getViewData();
-		}
-	}
 	return app.vault.read(file);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,22 @@
 import { App, MarkdownView, TFile } from "obsidian";
 
+// The editor buffer and the bytes on disk can disagree without the file
+// having been modified: CodeMirror normalizes line endings to "\n" and the
+// trailing newline may differ between the two. Canonicalize both sources so
+// comparing contents read through different paths never reports a change
+// for a byte-identical file (see issue #17).
+function normalizeForComparison(content: string): string {
+	return content.replace(/\r\n?/g, "\n").replace(/\n$/, "");
+}
+
+// Returns the file content in a canonical form suitable only for change
+// detection, preferring the (possibly unsaved) editor buffer over disk.
 export async function getFileContent(app: App, file: TFile): Promise<string> {
 	for (const leaf of app.workspace.getLeavesOfType("markdown")) {
 		const view = leaf.view;
 		if (view instanceof MarkdownView && view.file?.path === file.path) {
-			return view.getViewData();
+			return normalizeForComparison(view.getViewData());
 		}
 	}
-	return app.vault.read(file);
+	return normalizeForComparison(await app.vault.read(file));
 }


### PR DESCRIPTION
## Problem

On first open of a note (cold open), the `modified` timestamp was being bumped even though the file content was byte-identical. This occurred when a note was created by an external process (not through Obsidian's APIs).

## Root Cause

The `getFileContent()` function read from two different sources:
- **Editor open**: `view.getViewData()` (CodeMirror buffer)
- **Editor closed**: `app.vault.read(file)` (raw disk bytes)

These sources can disagree on line endings and trailing newlines without the file content actually changing. CodeMirror normalizes to `\n` and handles trailing newlines differently than raw disk reads. On a cold open:
1. Initial checksum from `app.vault.read()` (raw bytes with potential Windows line endings or trailing newline inconsistencies)
2. On tab switch, checksum from `view.getViewData()` (normalized by CodeMirror)
3. Mismatch detected → false "content changed" → `modified` bumped

## Solution

Normalize line endings and trailing newlines consistently for both sources before comparison:
- Standardize line endings to `\n` (handle `\r\n` and `\r`)
- Remove trailing newlines for consistent comparison

This ensures:
- ✅ No false positives when content is byte-identical but line endings differ
- ✅ Preserves ability to detect actual unsaved edits in the editor buffer (only detected if normalized buffers differ)
- ✅ Works regardless of platform or editor state
- ✅ No race conditions or timing assumptions

Fixes: #17