### PR TITLE
Fix false timestamp updates in reading mode and canvas (resolves #20)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 
 	private pendingNewFiles = new Set<string>();
 	private pendingModifiedUpdates = new Map<string, number>();
+	private fileChangeQueue: Promise<void> = Promise.resolve();
 
 	private isPathExcluded(filePath: string): boolean {
 		// Immediate return if there are no excluded folders
@@ -181,11 +182,17 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 		}
 	}
 
-	async handleFileChange() {
+	handleFileChange() {
+		this.fileChangeQueue = this.fileChangeQueue
+			.catch(() => {})
+			.then(() => this.processFileChange());
+	}
+
+	private async processFileChange() {
 		const { debug } = this.settings;
-		const markdownView =
-			this.app.workspace.getActiveViewOfType(MarkdownView);
-		const currentFile = markdownView ? markdownView.file : null;
+		const activeFile = this.app.workspace.getActiveFile();
+		const currentFile =
+			activeFile && activeFile.extension === "md" ? activeFile : null;
 
 		if (debug) {
 			console.log("handleFileChange called");
@@ -206,7 +213,7 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 							this.app,
 							this.lastActiveFile,
 						);
-						if (this.lastChecksum !== currentChecksum) {
+						if (this.lastChecksum !== null && this.lastChecksum !== currentChecksum) {
 							if (debug) {
 								console.log(
 									`File ${this.lastActiveFile.path} changed while inactive, updating modified time.`,
@@ -249,7 +256,7 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 						this.app,
 						this.lastActiveFile,
 					);
-					if (this.lastChecksum !== lastFileChecksum) {
+					if (this.lastChecksum !== null && this.lastChecksum !== lastFileChecksum) {
 						if (debug) {
 							console.log(
 								`File ${this.lastActiveFile.path} changed before switching, updating modified time.`,
@@ -271,8 +278,9 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 			!this.lastActiveFile ||
 			this.lastActiveFile.path !== currentFile.path
 		) {
+			const checksum = await getFileContent(this.app, currentFile);
 			this.lastActiveFile = currentFile;
-			this.lastChecksum = await getFileContent(this.app, currentFile);
+			this.lastChecksum = checksum;
 		}
 	}
 
@@ -290,12 +298,11 @@ export default class FrontMatterTimestampsPlugin extends Plugin {
 
 		const apply = async () => {
 			if (!immediate) {
-				const activeView =
-					this.app.workspace.getActiveViewOfType(MarkdownView);
-				if (activeView?.file?.path === file.path) {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (activeFile?.path === file.path) {
 					if (debug) {
 						console.log(
-							`Skipping modified time update for ${file.path}; file is the active editor.`,
+							`Skipping modified time update for ${file.path}; file is currently active.`,
 						);
 					}
 					return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,8 +4,10 @@ export async function getFileContent(app: App, file: TFile): Promise<string> {
 	for (const leaf of app.workspace.getLeavesOfType("markdown")) {
 		const view = leaf.view;
 		if (view instanceof MarkdownView && view.file?.path === file.path) {
-			return view.getViewData();
+			await view.save();
+			break;
 		}
 	}
-	return app.vault.read(file);
+	const content = await app.vault.read(file);
+	return content.replace(/\r\n/g, "\n");
 }


### PR DESCRIPTION
Resolves #20

### Summary of Changes

Fixes an issue where viewing a note in Reading/Preview mode or navigating to it from non-markdown views (such as Canvas or Bases) would inadvertently trigger a modification timestamp update in the frontmatter without any user edits.

### Root Causes

1. **Editor-only view check**: `workspace.getActiveViewOfType(MarkdownView)` returns `null` when in Reading/Preview mode or when focus is outside the text editor. This caused the plugin to believe no file was active, triggering the inactive file update logic and failing the active-file guard in `apply()`.
2. **Async race condition & null checksum comparison**: Navigating from non-markdown views (Canvas, Bases) clears `lastChecksum` to `null`. Rapid successive `active-leaf-change` events caused `null !== currentChecksum` to evaluate to `true`, triggering a false update before the baseline checksum was stored.
3. **`getViewData()` discrepancies**: Relying on `view.getViewData()` can yield inconsistent strings (or empty strings during view mounting in preview mode) compared to `vault.read()`.

### Solution
- Switched to `app.workspace.getActiveFile()` to reliably detect active markdown notes across all view modes (Reading, Live Preview, Source).
- Guaranteed that a `null` baseline checksum (`lastChecksum !== null`) never triggers a modified time update.
- Atomically assigned `lastActiveFile` and `lastChecksum` after `getFileContent` resolves.
- Serialized `handleFileChange` via a promise queue to prevent interleaved leaf-change events.
- Updated `getFileContent` to flush pending editor changes with `await view.save()` (if open) and consistently retrieve the content via `vault.read()`, normalized to `\n`.